### PR TITLE
Add missing resource types to security whitelist

### DIFF
--- a/src/services/security.js
+++ b/src/services/security.js
@@ -70,13 +70,15 @@ var ccdsScopes = [
 var allowedResources = [
   "AllergyIntolerance",
   "Condition",
-  "MedicationOrder",
-  "MedicationDispense",
-  "MedicationStatement",
-  "Observation",
+  "DocumentReference",
   "Encounter",
   "Immunization",
-  "Procedure",
+  "MedicationAdministration",
+  "MedicationDispense",
+  "MedicationOrder",
+  "MedicationStatement",
+  "Observation",
   "Patient",
-  "Practitioner"
+  "Practitioner",
+  "Procedure"
 ]


### PR DESCRIPTION
Alphabetize and add two resource types to security whitelist. Fixes https://github.com/sync-for-science/tracking/issues/10.
