### PR TITLE
Fix bug where refresh tokens were expiring in 5 minutes

### DIFF
--- a/src/services/database.js
+++ b/src/services/database.js
@@ -13,11 +13,13 @@ function SqliteMethod(path) {
   db.serialize();
 
   var refreshTokenColumns = [
+    "id INTEGER PRIMARY KEY AUTOINCREMENT",
     "client_id TEXT",
     "refresh_token TEXT",
     "revoked_at INTEGER NULL DEFAULT NULL"
   ];
   var accessTokenColumns = [
+    "id INTEGER PRIMARY KEY AUTOINCREMENT",
     "access_token TEXT",
     "iat INTEGER",
     "exp INTEGER",

--- a/src/services/token.js
+++ b/src/services/token.js
@@ -28,12 +28,15 @@ function NoneMethod(){
      */
     generate: function(grant){
       var config = require("../config");
-      var refresh;
+      var refresh, refresh_grant;
       var scope = grant.scope;
       var client_id = grant.client_id;
 
       if (scope.indexOf("offline_access") !== -1) {
-        refresh = jwt.sign(Object.assign({}, grant, {grant_type: "refresh_token"}), config.jwtSecret);
+        refresh_grant = Object.assign({}, grant, {grant_type: "refresh_token"});
+        delete refresh_grant["exp"];
+
+        refresh = jwt.sign(refresh_grant, config.jwtSecret);
       }
 
       var token = Object.assign({}, grant.context || {},  {


### PR DESCRIPTION
Refresh tokens were inheriting from the authorization code. This is fine for most properties, since it sets reasonable and pre-approved scopes, etc, but is not correct for expiration times.

Fixes https://github.com/sync-for-science/tracking/issues/23
